### PR TITLE
Suggestion to clarify path to run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Under MIT.
 ## Use
 
 ~~~
-$ swc-shell-split-window.sh
+$ ./swc-shell-split-window.sh
 ~~~
 
 ## Screenshot


### PR DESCRIPTION
Thanks for this tool - I used it setting up for SWC instructor checkout with `./swc-shell-split-window.sh` and plan to use it in future too.

My understanding is that the command under **Use** section won't work as written for many people if they don't have the current directory added to their $PATH, so it'd be helpful to either add `./` to the start of the example and/or add a note that this may be necessary