### PR TITLE
Make history log files session-dependent by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ $ ./swc-shell-split-window.sh
 
 Various environment variables affect the behaviour of the script, these are:
 
+ * `SESSION`:       The name of the session (default: swc)
  * `LOG_FILE`:      The location where the log file will be stored (default: /tmp/swc-split-log-file)
  * `HISTORY_LINES`: How many lines of history to be shown (default: 5)
- * `SESSION`:       The name of the session (default: swc)
  * `BGCOLOR`:       Background colour of the session
 
 These can be used with, e.g.:
@@ -47,8 +47,8 @@ about Git Conflicts.
 To do so, you would want to start to sessions in separate terminal windows with,
 e.g.:
 
-    LOG_FILE=/tmp/session1 BGCOLOR=12 ./swc-shell-split-window.sh
-    LOG_FILE=/tmp/session2 BGCOLOR=90 ./swc-shell-split-window.sh
+    SESSION=swc1 BGCOLOR=12 ./swc-shell-split-window.sh
+    SESSION=swc2 BGCOLOR=90 ./swc-shell-split-window.sh
 
 You can print all the available colours using:
 

--- a/swc-shell-split-window.sh
+++ b/swc-shell-split-window.sh
@@ -3,19 +3,19 @@
 # Create terminal for Software Carpentry lesson
 # with the log of the commands at the top.
 
+# Session name.  Defaults to 'swc', but you can override from the
+# calling process.
+SESSION="${SESSION:-swc}"
+
 # Where we'll store the executed history.  Defaults to /tmp/log-file,
 # but you can override from the calling process.  For example:
 #
 #   LOG_FILE=/tmp/my-log ./swc-shell-split-window.sh
-LOG_FILE="${LOG_FILE:-/tmp/swc-split-log-file}"
+LOG_FILE="${LOG_FILE:-/tmp/$SESSION-split-log-file}"
 
 # The number of lines of history to show.  Defaults to 5, but you can
 # override from the calling process.
 HISTORY_LINES="${HISTORY_LINES:-5}"
-
-# Session name.  Defaults to 'swc', but you can override from the
-# calling process.
-SESSION="${SESSION:-swc}"
 
 # If $LOG_FILE exists, truncate it, otherwise create it.
 # Either way, this leaves us with an empty $LOG_FILE for tailing.


### PR DESCRIPTION
The documentation says "To do so [role play as different users], you would want to start to sessions in separate terminal windows [...]" with a command like `LOG_FILE=/tmp/session1 BGCOLOR=12 ./swc-shell-split-window.sh`. If you actually try to do this in parallel, it fails because the session name is the same both times, so the two windows are clones of each other (with admittedly a quite nice effect of having different background colours for the upper and lower panes).

This PR changes the documentation to recommend changing the SESSION variable instead in this situation. So that this "just works" with least surprise, it also makes the default value of LOG_FILE dependent on the SESSION variable instead of being hard-coded, so each session gets its own history unless you explicitly make them share.
